### PR TITLE
Use img tags instead of background-images

### DIFF
--- a/src/assets/scss/layout/_footer.scss
+++ b/src/assets/scss/layout/_footer.scss
@@ -60,3 +60,9 @@
 
 		padding-bottom: 0px;
 	}
+
+	.donations-address-container{
+		@media only screen and (max-width: 767.9px){
+			overflow: auto;
+		}
+	}

--- a/src/assets/scss/sponsors.scss
+++ b/src/assets/scss/sponsors.scss
@@ -11,13 +11,6 @@
         max-width: 100%;
     }
 
-    @each $sponsor in sponsor1, sponsor2, sponsor3, sponsor4, sponsor5, sponsor6, sponsor7, sponsor8, sponsor9, sponsor10, sponsor11, sponsor12, sponsor13, {
-        .#{$sponsor} {
-            background-image: url('../images/sponsors/#{$sponsor}.jpg');
-            max-width: 100%;
-        }
-    }
-
     .clearfix{
         clear: both;
     }

--- a/src/assets/scss/sponsors.scss
+++ b/src/assets/scss/sponsors.scss
@@ -51,11 +51,18 @@
             justify-content: space-around;
         }
         .sponsor-logo{
-            width: 150px;
-            height: 150px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            img{
+                width: 150px;
+            }
         }
-        .sponsor11{
-            background-size: contain;
+        .sponsor-name{
+            padding-top: 15px;
+            @media only screen and (min-width: 992px){
+                padding-top: 30px;
+            }
         }
     }
 }

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -12,7 +12,7 @@ const Footer = props => (
         </dd>
       </dl>
       <h2>Donations:</h2>
-      <dl className="alt">
+      <dl className="alt donations-address-container">
         <dt>BCH:</dt>
         <dd>
           <a href="bitcoincash:pr508v7nem4z67u82rh5qqtpcctzkw6gfvdyvk6ag2">bitcoincash:pr508v7nem4z67u82rh5qqtpcctzkw6gfvdyvk6ag2</a>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -18,6 +18,9 @@ import donateIcon from '../assets/images/join/donate.svg'
 import helpIcon from '../assets/images/join/help.svg'
 import person from '../assets/images/person.jpg'
 import githubIcon from '../assets/images/github.svg'
+import fullstackIcon from '../assets/images/sponsors/sponsor11.jpg'
+import generalProtocolsIcon from '../assets/images/sponsors/sponsor12.jpg'
+import bitcoinBayIcon from '../assets/images/sponsors/sponsor13.jpg'
 
 class Index extends React.Component {
   constructor(props) {
@@ -156,10 +159,24 @@ class Index extends React.Component {
 
               </div>
               <div className="sm-sponsors">
-                <a href="https://fullstack.cash/" target="_blank"><div className="sponsor-logo image sponsor11"><br></br><br></br><br></br><br></br><br></br><br></br><span>FullStack.cash</span></div></a>
-                <a href="https://generalprotocols.com/" target="_blank"><div className="sponsor-logo image sponsor12"><br></br><br></br><br></br><br></br><br></br><br></br><span>General Protocols</span></div></a>
-                <a href="https://bitcoinbay.ca/" target="_blank"><div className="sponsor-logo image sponsor13"><br></br><br></br><br></br><br></br><br></br><br></br><span>Bitcoin Bay</span></div></a>
-
+                <a href="https://fullstack.cash/" target="_blank">
+                  <div className="sponsor-logo">
+                    <img src={fullstackIcon} alt="FullStack.cash" />
+                  </div>
+                  <p className="sponsor-name">FullStack.cash</p>
+                </a>
+                <a href="https://generalprotocols.com/" target="_blank">
+                  <div className="sponsor-logo">
+                    <img className="sponsor-logo" src={generalProtocolsIcon} alt="General Protocols" />
+                  </div>
+                  <p className="sponsor-name">General Protocols</p>
+                </a>
+                <a href="https://bitcoinbay.ca/" target="_blank">
+                  <div className="sponsor-logo">
+                    <img className="sponsor-logo" src={bitcoinBayIcon} alt="Bitcoin Bay" />
+                  </div>
+                  <p className="sponsor-name">Bitcoin Bay</p>
+                </a>
               </div>
             </ul>
           </section>


### PR DESCRIPTION
**Changes made**

• Replace divs with background-image with img tags in sponsors section
• Remove unused sass loop 
• Add overflow auto to the donations addresses container (only in mobile) 